### PR TITLE
Credential mismatch in user schema

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -117,7 +117,7 @@ class UserCreate(UserBase):
         ...,
         min_length=8,
         description="A strong password for the user's account. Must be at least 8 characters long and include uppercase and lowercase letters, a digit, and a special character.",
-        example="SecurePassword123!"
+        example="StrongPassword123!"
     )
 
     @validator('password')
@@ -140,7 +140,7 @@ class UserCreate(UserBase):
             "example": {
                 "username": "john_doe_123",
                 "email": "john.doe@example.com",
-                "password": "SecurePassword123!",
+                "password": "StrongPassword123!",
                 "full_name": "John Doe",
                 "bio": "I am a data scientist passionate about machine learning and big data analytics.",
                 "profile_picture_url": "https://example.com/profile_pictures/jane_smith.jpg"
@@ -325,7 +325,7 @@ class LoginRequest(BaseModel):
     password: str = Field(
         ...,
         description="Password of the user trying to login.",
-        example="SecurePassword123!"
+        example="StrongPassword123!"
     )
 
     class Config:
@@ -333,7 +333,7 @@ class LoginRequest(BaseModel):
             "description": "Model for user login request.",
             "example": {
                 "username": "john_doe_123",
-                "password": "SecurePassword123!"
+                "password": "StrongPassword123!"
             }
         }
 

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -16,7 +16,7 @@ def user_base_data():
 
 @pytest.fixture
 def user_create_data(user_base_data):
-    return {**user_base_data, "password": "SecurePassword123!"}
+    return {**user_base_data, "password": "StrongPassword123!"}
 
 @pytest.fixture
 def user_update_data():
@@ -41,7 +41,7 @@ def user_response_data():
 
 @pytest.fixture
 def login_request_data():
-    return {"username": "john_doe_123", "password": "SecurePassword123!"}
+    return {"username": "john_doe_123", "password": "StrongPassword123!"}
 
 # Tests for UserBase
 def test_user_base_valid(user_base_data):


### PR DESCRIPTION
Credential mismatch in user schema does not allow users to login and register to the application either in FastAPI/Swagger or through the production application